### PR TITLE
Add Rails 7 support

### DIFF
--- a/lib/native_enum.rb
+++ b/lib/native_enum.rb
@@ -7,8 +7,10 @@ require 'connection_adapters/mysql2' if defined?( Mysql2 )
 
 if ActiveRecord::VERSION::MAJOR < 4 || (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR <= 1)
   require 'native_enum/activerecord_enum_pre42.rb'
-else
+elsif ActiveRecord::VERSION::MAJOR < 7
   require 'native_enum/activerecord_enum_post42.rb'
+else
+  require 'native_enum/activerecord_enum_post7.rb'
 end
 
 module ActiveRecord

--- a/lib/native_enum/activerecord_enum_post7.rb
+++ b/lib/native_enum/activerecord_enum_post7.rb
@@ -1,0 +1,69 @@
+module ActiveRecord
+  module ConnectionAdapters
+    if defined?(AbstractMysqlAdapter)
+      class AbstractMysqlAdapter
+        class << self
+          def initialize_type_map_with_enum(m = type_map)
+            initialize_without_enum(m)
+            register_enum_type(m, %r(^enum)i)
+            register_set_type(m, %r(^set)i)
+          end
+
+          alias_method :initialize_without_enum, :initialize_type_map
+          alias_method :initialize_type_map, :initialize_type_map_with_enum
+
+          def register_enum_type(mapping, key)
+            mapping.register_type(key) do |sql_type|
+              if sql_type =~ /(?:enum)\(([^)]+)\)/i
+                limit = $1.scan( /'([^']*)'/ ).flatten
+                Type::Enum.new(limit: limit)
+              end
+            end
+          end
+
+          def register_set_type(mapping, key)
+            mapping.register_type(key) do |sql_type|
+              if sql_type =~ /(?:set)\(([^)]+)\)/i
+                limit = $1.scan( /'([^']*)'/ ).flatten
+                Type::Set.new(limit: limit)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  module Type
+    class Enum < Type::Value
+      def type
+        :enum
+      end
+
+      def initialize(options = {})
+        options.assert_valid_keys(:limit)
+        @limit = options[:limit]
+      end
+    end
+
+    class Set < Type::Value
+      def type
+        :set
+      end
+
+      def initialize(options = {})
+        options.assert_valid_keys(:limit)
+        @limit = options[:limit]
+      end
+
+      # Deserialize value from the database
+      #
+      # See: https://github.com/rails/rails/blob/v5.0.7/activemodel/lib/active_model/type/value.rb#L15-L23
+      def deserialize(value)
+        value.split(",")
+      end
+      # deserialize used to be called type_cast_from_database before v5
+      alias_method :type_cast_from_database, :deserialize
+    end
+  end
+end


### PR DESCRIPTION
## Why? / What?
We are blocked from upgrading to Rails 7 by this gem. In order to make this gem compatible, I added `native_enum/activerecord_enum_post42.rb`, which is written to work with [changes in version 7 of the ActiveRecord gem](https://github.com/rails/rails/pull/42773/files#diff-868f1dccfcbed26a288bf9f3fd8a39c863a4413ab0075e12b6805d9798f556d1R564).

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.

### Screenshot(s)
NA
### JIRA Link
https://sentera.atlassian.net/browse/PAGC-794
## Migrations Required?
NA
## Data Recovery Strategy
NA
## QA Strategy
- [ ] Merge Latest Master
- [ ] Regression test database columns that use MySQL's native `enum` data type
  - [ ] `alerts.details`
  - [ ] `analytics.details`
  - [ ] `analytics.processing_details`
  - [ ] `cogs.bbox`
  - [ ] `cogs.coger_args`
  - [ ] `cogs.bands`
  - [ ] `field_activities.details`
  - [ ] `mosaics.bands`
  - [ ] `organizations.premium_analytics`
  - [ ] `organizations.generated_notifications`
  - [ ] `users.preferences`
  - [ ] `webhook_events.payload`
